### PR TITLE
fix: improve macOS compatibility and correct scaffolding script issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
-new.sh
-rename.sh
-TEST-vite-env.sh
-TEST-vite-test.sh
-VIP-window-manipulation.sh
-vite-tailwind.sh
+# macOS system file
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,16 +2,23 @@
 
 ## Version
 
-### Current version: 0.0.5
-- **Release Date**: October 15, 2025
-- **Features**:
-  - Updated mechanism for dependency selection — now fully managed via `install-config.env` instead of editing the main script:
-    - Added automatic creation of a default `install-config.env` file if it does not exist.
-    - Added verification of key-value pairs in `install-config.env` using the `allowed_keys` array.
-    - Expanded deployment script registration to require mapping each script both in the `allowed_keys` array and in the “Deployment scripts” section of the main script.
-  - Updated the Vite installation step to suppress default prompts asking to install dependencies or run the project (these are handled by the script).
+### Current version: 0.0.7
+- **Release Date**: February 22, 2025
+- **Fixes**:
+  - Fixed compatibility with BSD/macOS: All `sed -i` calls now use a backup parameter, ensuring scripts execute correctly on macOS and other BSD systems.
+  - Fixed the incorrect deployment parameter: The script now uses the correct `INSTALL_REACT_HOT_TOAST` variable, matching the config and deployment logic.
+  - Vite scaffolding: Removed the `yes n |` pipe in favor of the `--no-interactive` flag for Vite, ensuring predictable and reliable project setup.
+  - Indentation change: Scripts now use consistent indentation as per VS Code settings (this is intentional and will be kept).
+- **Known issues**:
+  - On BSD systems (including macOS), using `echo -e` with ANSI color codes (e.g., `\e[31m`) may print the escape sequences literally instead of applying color. This issue doesn't affect script functionality.
 
 ### Version history:
+  - **0.0.6** (October 15, 2025)
+    - Updated mechanism for dependency selection — now fully managed via `install-config.env` instead of editing the main script:
+      - Added automatic creation of a default `install-config.env` file if it does not exist.
+      - Added verification of key-value pairs in `install-config.env` using the `allowed_keys` array.
+      - Expanded deployment script registration to require mapping each script both in the `allowed_keys` array and in the “Deployment scripts” section of the main script.
+    - Updated the Vite installation step to suppress default prompts asking to install dependencies or run the project (these are handled by the script).
   - **0.0.5** (September 22, 2025)
     - Split `tailwind-daisyUi.sh` into two separate scripts, `tailwind.sh` and `daisyUi.sh`, to allow finer control over which packages are installed by the `vite-react.sh` script.
     - Clears the content of the `README.md` file when deploying the `vite-react.sh` script.

--- a/vite-react-deployment-scripts/daisyUi.sh
+++ b/vite-react-deployment-scripts/daisyUi.sh
@@ -36,7 +36,8 @@ fi
 if file_exists "./index.html"; then
 
 	# Add the "data-theme" attribute to the "html" tag (apply daisyUi light theme by default)
-	sed -i 's/<html lang="en">/<html lang="en" data-theme="dark">/' index.html
+	# sed -i 's/<html lang="en">/<html lang="en" data-theme="dark">/' index.html
+	sed -i.bak 's/<html lang="en">/<html lang="en" data-theme="dark">/' index.html && rm index.html.bak
 	echo
 	echo "Added 'data-theme' attribute to the 'html' tag in 'index.html'."
 	echo

--- a/vite-react.sh
+++ b/vite-react.sh
@@ -15,7 +15,7 @@ echo  "     ###########################################################"
 echo -e "     ##             \e[35mVITE + REACT + DEPENDENCIES\e[0m               ##"
 echo -e "     ##                 \e[31mInstallation script\e[0m                   ##"
 echo  "     ###########################################################"
-echo	
+echo  
 echo
 
 # #######################################################################################
@@ -154,30 +154,30 @@ echo "########## SCAFFOLDING THE PROJECT ##########"
 echo
 
 # * Create vite->react->js-swc project in the current folder
-yes n | npm create vite@latest . -- --template react-swc
+npm create vite@latest . -- --template react-swc --no-interactive
 
 while true; do
   # * Ask the user if they want to continue. Allow the user to exit script if Vite scaffolding fails or is aborted
-	read -p $'\e[1;35mWould you like to continue? (Y/N): \e[0m' choice
+  read -p $'\e[1;35mWould you like to continue? (Y/N): \e[0m' choice
 
-	# * Convert the input to uppercase for case-insensitive comparison
-	choice=$(convert_to_uppercase "$choice")
+  # * Convert the input to uppercase for case-insensitive comparison
+  choice=$(convert_to_uppercase "$choice")
 
-	# * Check if the input is valid
-	if [ "$choice" = "Y" ]; then
-		# Exit the loop if the input is valid
-		break  
-	elif [ "$choice" = "N" ]; then
-		echo
-		echo "Aborting the script"
-		echo
-		# Exit the script with a non-zero status (indicate failure)
-		exit 1
-	else
-		echo
-		echo "$invalid_input_message"
-		echo
-	fi
+  # * Check if the input is valid
+  if [ "$choice" = "Y" ]; then
+    # Exit the loop if the input is valid
+    break  
+  elif [ "$choice" = "N" ]; then
+    echo
+    echo "Aborting the script"
+    echo
+    # Exit the script with a non-zero status (indicate failure)
+    exit 1
+  else
+    echo
+    echo "$invalid_input_message"
+    echo
+  fi
 done
 
 # * Install NPM
@@ -201,7 +201,7 @@ echo
 [ "$INSTALL_SPINNERS" = true ] && "$deployment_script_dir/react-spinners.sh"
 [ "$INSTALL_FONT_AWESOME" = true ] && "$deployment_script_dir/font-awesome.sh"
 [ "$INSTALL_CLASSNAMES" = true ] && "$deployment_script_dir/class-names.sh"
-[ "$INSTALL_TOAST" = true ] && "$deployment_script_dir/react-hot-toast.sh"
+[ "$INSTALL_REACT_HOT_TOAST" = true ] && "$deployment_script_dir/react-hot-toast.sh"
 [ "$INSTALL_HEADLESSUI" = true ] && "$deployment_script_dir/headless-ui.sh"
 
 # #######################################################################################
@@ -219,43 +219,43 @@ echo "Created .env"
 
 while true; do
   # * Check how to modify the .env file
-	echo
-	read -p $'\e[1;35mUse Chrome as default browser to run the project locally? (Y/N): \e[0m' choice
+  echo
+  read -p $'\e[1;35mUse Chrome as default browser to run the project locally? (Y/N): \e[0m' choice
 
-	# * Convert the input to uppercase for case-insensitive comparison
-	choice=$(convert_to_uppercase "$choice")
+  # * Convert the input to uppercase for case-insensitive comparison
+  choice=$(convert_to_uppercase "$choice")
 
-	if [ "$choice" = "Y" ]; then
-		while true; do
-			echo
-			read -p $'\e[1;35mWindows + WSL (Y) or Ubuntu (N)? (Y/N): \e[0m' choice
-			choice=$(convert_to_uppercase "$choice")
-			# * Set BROWSER variable to Chrome in the .env file
-			if [ "$choice" = "Y" ]; then
-				echo 'BROWSER="/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"' >> .env
-				echo
-				echo "Set the browser to 'google-chrome' in .env"
-				break
-			elif [ "$choice" = "N" ]; then
-				echo "BROWSER=google-chrome" >> .env
-				echo
-				echo "Set the browser to 'google-chrome' in .env"
-				break
-			else
-				echo
-				echo "$invalid_input_message"
-				echo
-			fi
-		done
-		break
-	# terminate the loop
-	elif [ "$choice" = "N" ]; then
-		break
-	else
-		echo
-		echo "$invalid_input_message"
-		echo
-	fi
+  if [ "$choice" = "Y" ]; then
+    while true; do
+      echo
+      read -p $'\e[1;35mWindows + WSL (Y) or Ubuntu (N)? (Y/N): \e[0m' choice
+      choice=$(convert_to_uppercase "$choice")
+      # * Set BROWSER variable to Chrome in the .env file
+      if [ "$choice" = "Y" ]; then
+        echo 'BROWSER="/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"' >> .env
+        echo
+        echo "Set the browser to 'google-chrome' in .env"
+        break
+      elif [ "$choice" = "N" ]; then
+        echo "BROWSER=google-chrome" >> .env
+        echo
+        echo "Set the browser to 'google-chrome' in .env"
+        break
+      else
+        echo
+        echo "$invalid_input_message"
+        echo
+      fi
+    done
+    break
+  # terminate the loop
+  elif [ "$choice" = "N" ]; then
+    break
+  else
+    echo
+    echo "$invalid_input_message"
+    echo
+  fi
 done
 
 # Add .env file to .gitignore
@@ -268,87 +268,91 @@ echo "Added .env to .gitignore"
 # * Modify the "dev" script in package.json to include .env variables
 # Check if package.json exists
 if [ -f "package.json" ]; then
-	# Use sed to modify the "dev" script in package.json
-	sed -i 's/"dev": "vite",/"dev": "vite --open $BROWSER",/' package.json
-	echo
-	echo "Modified 'dev' script in package.json"
+  # Use sed to modify the "dev" script in package.json
+  # sed -i 's/"dev": "vite",/"dev": "vite --open $BROWSER",/' package.json
+  sed -i.bak 's/"dev": "vite",/"dev": "vite --open $BROWSER",/' package.json && rm package.json.bak
+  echo
+  echo "Modified 'dev' script in package.json"
 else
-	echo
-	echo "Error: package.json not found"
+  echo
+  echo "Error: package.json not found"
 fi
 
 # * Modify the "rules" script in ./eslint.config.js (disable some of the eslint validations which might be a bit annoying)
 if [ -f "./eslint.config.js" ]; then
-	# Use sed to modify the './eslint.config.js' file
-	sed -i "s|'react/jsx-no-target-blank': 'off',|'react/prop-types': 'off',\n      'react/jsx-no-target-blank': 'off',|" ./eslint.config.js
-	# sed -i "s|env: { browser: true, es2020: true },|env: { browser: true, es2020: true, node: true },|" ./eslint.config.js
-	echo
-	echo "Modified 'rules' in ./eslint.config.js"
+  # Use sed to modify the './eslint.config.js' file
+  # sed -i "s|'react/jsx-no-target-blank': 'off',|'react/prop-types': 'off',\n      'react/jsx-no-target-blank': 'off',|" ./eslint.config.js
+  sed -i.bak "s|'react/jsx-no-target-blank': 'off',|'react/prop-types': 'off',\n      'react/jsx-no-target-blank': 'off',|" ./eslint.config.js && rm eslint.config.js.bak
+  # sed -i "s|env: { browser: true, es2020: true },|env: { browser: true, es2020: true, node: true },|" ./eslint.config.js
+  echo
+  echo "Modified 'rules' in ./eslint.config.js"
 else
-	echo
-	echo "Error: ./eslint.config.js not found"
+  echo
+  echo "Error: ./eslint.config.js not found"
 fi
 
 # * Check if the file "./src/App.jsx" exists to clear its content
 if file_exists "./src/App.jsx"; then
-	# Clear the content of ./src/App.jsx
-	> ./src/App.jsx
+  # Clear the content of ./src/App.jsx
+  > ./src/App.jsx
 
 # ! this section will modify the app.jsx file to include Tailwind and daisyUi classes
 # ! this is to confirm if these were successfully installed, when the project loads the styling should take effect
 # ! can be disabled if not using Tailwind
 # Update ./src/App.jsx with the provided content
-	echo "import './App.css'" >> ./src/App.jsx
-	echo "" >> ./src/App.jsx
-	echo "function App() {" >> ./src/App.jsx
-	echo "  return (" >> ./src/App.jsx
-	echo "    <>" >> ./src/App.jsx
-	echo "      <div className='flex flex-col justify-center items-center gap-6 h-screen text-base-content'>" >> ./src/App.jsx
-	echo "        <h1 className='text-6xl'>HAPPY CODING!</h1>" >> ./src/App.jsx
-	echo "        <button" >> ./src/App.jsx
-	echo "          className='btn btn-primary'" >> ./src/App.jsx
-	echo "          onClick={() => {alert(\"You've just pressed the button. Well done!\")}}" >> ./src/App.jsx
-	echo "        >" >> ./src/App.jsx
-	echo "          Test button" >> ./src/App.jsx
-	echo "        </button>" >> ./src/App.jsx
-	echo "      </div>" >> ./src/App.jsx
-	echo "    </>" >> ./src/App.jsx
-	echo "  )" >> ./src/App.jsx
-	echo "}" >> ./src/App.jsx
-	echo "" >> ./src/App.jsx
-	echo "export default App" >> ./src/App.jsx
-	echo "" >> ./src/App.jsx
-	echo
-	echo "Modified ./src/App.jsx"
+  echo "import './App.css'" >> ./src/App.jsx
+  echo "" >> ./src/App.jsx
+  echo "function App() {" >> ./src/App.jsx
+  echo "  return (" >> ./src/App.jsx
+  echo "    <>" >> ./src/App.jsx
+  echo "      <div className='flex flex-col justify-center items-center gap-6 h-screen text-base-content'>" >> ./src/App.jsx
+  echo "        <h1 className='text-6xl'>HAPPY CODING!</h1>" >> ./src/App.jsx
+  echo "        <button" >> ./src/App.jsx
+  echo "          className='btn btn-primary'" >> ./src/App.jsx
+  echo "          onClick={() => {alert(\"You've just pressed the button. Well done!\")}}" >> ./src/App.jsx
+  echo "        >" >> ./src/App.jsx
+  echo "          Test button" >> ./src/App.jsx
+  echo "        </button>" >> ./src/App.jsx
+  echo "      </div>" >> ./src/App.jsx
+  echo "    </>" >> ./src/App.jsx
+  echo "  )" >> ./src/App.jsx
+  echo "}" >> ./src/App.jsx
+  echo "" >> ./src/App.jsx
+  echo "export default App" >> ./src/App.jsx
+  echo "" >> ./src/App.jsx
+  echo
+  echo "Modified ./src/App.jsx"
 else
-	echo
-	echo "Error: ./src/App.jsx not found"
+  echo
+  echo "Error: ./src/App.jsx not found"
 fi
 
 # * Check if the file "./index.html" exists to carry on with specific tasks
 if file_exists "./index.html"; then
 
-	# Update ./index.html with the provided content
-	sed -i 's/Vite + React/My Project/' index.html
-	sed -i 's|<link rel="icon" type="image/svg+xml" href="/vite.svg" />|<link rel="icon" type="" href="" />|' index.html
-	echo
-	echo "Modified ./index.html"
-	echo
+  # Update ./index.html with the provided content
+  # sed -i '' 's/Vite + React/My Project/' index.html
+  sed -i.bak 's/Vite + React/My Project/' index.html && rm index.html.bak
+  # sed -i '' 's|<link rel="icon" type="image/svg+xml" href="/vite.svg" />|<link rel="icon" type="" href="" />|' index.html
+  sed -i.bak 's|<link rel="icon" type="image/svg+xml" href="/vite.svg" />|<link rel="icon" type="" href="" />|' index.html && rm index.html.bak
+  echo
+  echo "Modified ./index.html"
+  echo
 else
-	echo
-	echo "Error: ./index.html not found"
-	echo
+  echo
+  echo "Error: ./index.html not found"
+  echo
 fi
 
 # * Check if the file "./src/App.css" exists to clear its content
 if file_exists "./src/App.css"; then
-	# Clear the content of ./src/App.css
-	> ./src/App.css
-	echo "Cleared ./src/App.css"
-	echo
+  # Clear the content of ./src/App.css
+  > ./src/App.css
+  echo "Cleared ./src/App.css"
+  echo
 else
-	echo "Error: ./src/App.css not found"
-	echo
+  echo "Error: ./src/App.css not found"
+  echo
 fi
 
 if is_commented "tailwind.sh" || is_commented "daisyUi.sh"; then
@@ -364,36 +368,36 @@ fi
 
 # Clear README.md file
 if file_exists "./README.md"; then
-	# Clear the content of README.md
-	> ./README.md
-	echo "Cleared ./README.md"
-	echo
+  # Clear the content of README.md
+  > ./README.md
+  echo "Cleared ./README.md"
+  echo
 else
-	echo "Error: README.md not found"
-	echo
+  echo "Error: README.md not found"
+  echo
 fi
 
 # * Check if directory "./src/assets" exists to clear its content
 if directory_exists "./src/assets"; then
-	# Force remove the content of the directory
-	rm -rf ./src/assets/*
-	echo "Content of ./src/assets removed"
-	echo
+  # Force remove the content of the directory
+  rm -rf ./src/assets/*
+  echo "Content of ./src/assets removed"
+  echo
 else
-	echo
-	echo "Error: ./src/assets not found"
-	echo
+  echo
+  echo "Error: ./src/assets not found"
+  echo
 fi
 
 # * Check if directory "./public" exists to clear its content
 if directory_exists "./public"; then
-	# force remove the content of the directory
-	rm -rf ./public/*
-	echo "Content of ./public removed"
-	echo
+  # force remove the content of the directory
+  rm -rf ./public/*
+  echo "Content of ./public removed"
+  echo
 else
-	echo "Error: ./public not found"
-	echo
+  echo "Error: ./public not found"
+  echo
 fi
 
 echo
@@ -406,38 +410,38 @@ echo
 
 echo
 while true; do
-	read -p $'\e[1;35mWould you like to disable React StrictMode? (Y/N): \e[0m' choice
+  read -p $'\e[1;35mWould you like to disable React StrictMode? (Y/N): \e[0m' choice
 
-	choice=$(convert_to_uppercase "$choice")
+  choice=$(convert_to_uppercase "$choice")
 
-	# * Check the user's choice to modify content of main.jsx file
-	if [ "$choice" = "Y" ]; then
-		# Check if file exists
-		if file_exists "./src/main.jsx"; then
-			# * Modify the content of ./src/main.jsx
-			# sed -i -E 's|^import React from '\''react'\''|// &|; s|<React.StrictMode>|//&|; s|</React.StrictMode>,|//&|' ./src/main.jsx
-			sed -i -E 's|^import \{ StrictMode \} from '\''react'\''|// &|; s|<StrictMode>|//&|; s|</StrictMode>|//&|' ./src/main.jsx
-			echo
-			echo "Modified ./src/main.jsx"
-			echo
-			echo
-			echo -e "\e[33m REACT STRICTMODE DISABLED\e[0m"
-			echo
-			echo
-			break
-		else
-			echo
-			echo "Error: ./src/main.jsx not found"
-			echo
-		fi
-	elif [ "$choice" = "N" ]; then
-		echo
-		break
-	else
-		echo
-		echo "$invalid_input_message"
-		echo
-	fi
+  # * Check the user's choice to modify content of main.jsx file
+  if [ "$choice" = "Y" ]; then
+    # Check if file exists
+    if file_exists "./src/main.jsx"; then
+      # * Modify the content of ./src/main.jsx
+      # sed -i -E 's|^import React from '\''react'\''|// &|; s|<React.StrictMode>|//&|; s|</React.StrictMode>,|//&|' ./src/main.jsx
+      sed -i.bak -E 's|^import \{ StrictMode \} from '\''react'\''|// &|; s|<StrictMode>|//&|; s|</StrictMode>|//&|' ./src/main.jsx && rm main.jsx.bak
+      echo
+      echo "Modified ./src/main.jsx"
+      echo
+      echo
+      echo -e "\e[33m REACT STRICTMODE DISABLED\e[0m"
+      echo
+      echo
+      break
+    else
+      echo
+      echo "Error: ./src/main.jsx not found"
+      echo
+    fi
+  elif [ "$choice" = "N" ]; then
+    echo
+    break
+  else
+    echo
+    echo "$invalid_input_message"
+    echo
+  fi
 done
 
 # #######################################################################################
@@ -445,24 +449,24 @@ done
 # #######################################################################################
 
 while true; do
-	read -p $'\e[1;35mWould you like to run VSCODE? (Y/N): \e[0m' choice
+  read -p $'\e[1;35mWould you like to run VSCODE? (Y/N): \e[0m' choice
 
-	choice=$(convert_to_uppercase "$choice")
+  choice=$(convert_to_uppercase "$choice")
 
-	# * Check the user's choice to run VS code
-	if [ "$choice" = "Y" ]; then
-		code .
-		sleep 2 && npm run dev
-		break
-	elif [ "$choice" = "N" ]; then
-		echo
-		echo "Exiting the script"
-		echo
-		# Exit the script with a non-zero status (indicate failure)
-		exit 1
-	else
-		echo
-		echo "$invalid_input_message"
-		echo
-	fi
+  # * Check the user's choice to run VS code
+  if [ "$choice" = "Y" ]; then
+    code .
+    sleep 2 && npm run dev
+    break
+  elif [ "$choice" = "N" ]; then
+    echo
+    echo "Exiting the script"
+    echo
+    # Exit the script with a non-zero status (indicate failure)
+    exit 1
+  else
+    echo
+    echo "$invalid_input_message"
+    echo
+  fi
 done


### PR DESCRIPTION
- BSD/macOS compatibility:
  - Updated all `sed -i` calls to include a backup suffix for BSD/macOS compatibility
  - Affected scripts:
    - vite-react.sh
    - daisyUi.sh

- vite-react.sh:
  - Corrected deployment parameter (INSTALL_TOAST → INSTALL_REACT_HOT_TOAST)
  - Removed `yes n |` pipe and replaced with Vite `--no-interactive` flag for predictable scaffolding
  - Standardized indentation to match VS Code settings (intentional change)

- README.md:
  - Updated to reflect the above changes

- .gitignore:
  - Added `.DS_Store` to prevent macOS system file pollution