### PR TITLE
fix: vite installation flag issue

### DIFF
--- a/vite-react.sh
+++ b/vite-react.sh
@@ -154,7 +154,7 @@ echo "########## SCAFFOLDING THE PROJECT ##########"
 echo
 
 # * Create vite->react->js-swc project in the current folder
-npm create vite@latest . -- --template react-swc --no-interactive
+npm create vite@latest . -- --template react --no-interactive
 
 while true; do
   # * Ask the user if they want to continue. Allow the user to exit script if Vite scaffolding fails or is aborted


### PR DESCRIPTION
- Using the `react-swc` template flag installs the TypeScript version of the template instead of the JavaScript one. To work around this, the `react-swc` flag was replaced with the `react` flag for the time being.